### PR TITLE
Match namespaces changes for Centurion-Creative-Connect/System#47

### DIFF
--- a/Packages/org.centurioncc.system.commands/Runtime/Command/GunUpdaterCommand.asset
+++ b/Packages/org.centurioncc.system.commands/Runtime/Command/GunUpdaterCommand.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   compiledVersion: 2
   behaviourSyncMode: 1
   hasInteractEvent: 0
-  scriptID: 3093293815987917206
+  scriptID: 3744415293463066677
   serializationData:
     SerializedFormat: 2
     SerializedBytes: 

--- a/Packages/org.centurioncc.system.commands/Runtime/Command/GunUpdaterCommand.cs
+++ b/Packages/org.centurioncc.system.commands/Runtime/Command/GunUpdaterCommand.cs
@@ -1,9 +1,10 @@
-﻿using DerpyNewbie.Common;
+﻿using CenturionCC.System.Gun.MassGun;
+using DerpyNewbie.Common;
 using DerpyNewbie.Logger;
 using UdonSharp;
 using UnityEngine;
 
-namespace CenturionCC.System.Gun.MassGun
+namespace CenturionCC.System.Command
 {
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class GunUpdaterCommand : NewbieConsoleCommandHandler

--- a/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerExternalCommand.asset
+++ b/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerExternalCommand.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   compiledVersion: 2
   behaviourSyncMode: 1
   hasInteractEvent: 0
-  scriptID: 3309621387226330216
+  scriptID: -6154884700769508972
   serializationData:
     SerializedFormat: 2
     SerializedBytes: 
@@ -206,19 +206,20 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: playerTagManager
+      Data: hitDisplayManager
     - Name: $v
       Entry: 7
       Data: 10|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: playerTagManager
+      Data: hitDisplayManager
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 11|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: CenturionCC.System.Player.PlayerExternal.ExternalPlayerTagManager, CenturionCC.System
+      Data: CenturionCC.System.Player.External.HitDisplay.ExternalHitDisplayManager,
+        CenturionCC.System
     - Name: 
       Entry: 8
       Data: 
@@ -278,19 +279,20 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: hitDisplayManager
+      Data: playerTagManager
     - Name: $v
       Entry: 7
       Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: hitDisplayManager
+      Data: playerTagManager
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 17|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: CenturionCC.System.Player.PlayerExternal.ExternalHitDisplayManager, CenturionCC.System
+      Data: CenturionCC.System.Player.External.PlayerTag.ExternalPlayerTagManager,
+        CenturionCC.System
     - Name: 
       Entry: 8
       Data: 

--- a/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerExternalCommand.cs
+++ b/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerExternalCommand.cs
@@ -1,17 +1,19 @@
-﻿using DerpyNewbie.Common;
+﻿using CenturionCC.System.Player.External.HitDisplay;
+using CenturionCC.System.Player.External.PlayerTag;
+using DerpyNewbie.Common;
 using DerpyNewbie.Logger;
 using UdonSharp;
 using UnityEngine;
 
-namespace CenturionCC.System.Player.PlayerExternal
+namespace CenturionCC.System.Command
 {
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class PlayerExternalCommand : NewbieConsoleCommandHandler
     {
         [SerializeField] [HideInInspector] [NewbieInject]
-        private ExternalPlayerTagManager playerTagManager;
-        [SerializeField] [HideInInspector] [NewbieInject]
         private ExternalHitDisplayManager hitDisplayManager;
+        [SerializeField] [HideInInspector] [NewbieInject]
+        private ExternalPlayerTagManager playerTagManager;
 
         public override string Label => "PlayerExternal";
         public override string[] Aliases => new[] { "PlayerExt", "PExt" };

--- a/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerUpdaterCommand.asset
+++ b/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerUpdaterCommand.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   compiledVersion: 2
   behaviourSyncMode: 1
   hasInteractEvent: 0
-  scriptID: -2352092413528101273
+  scriptID: 8034313310510411673
   serializationData:
     SerializedFormat: 2
     SerializedBytes: 

--- a/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerUpdaterCommand.cs
+++ b/Packages/org.centurioncc.system.commands/Runtime/Command/PlayerUpdaterCommand.cs
@@ -1,9 +1,10 @@
-﻿using DerpyNewbie.Common;
+﻿using CenturionCC.System.Player.MassPlayer;
+using DerpyNewbie.Common;
 using DerpyNewbie.Logger;
 using UdonSharp;
 using UnityEngine;
 
-namespace CenturionCC.System.Player.MassPlayer
+namespace CenturionCC.System.Command
 {
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class PlayerUpdaterCommand : NewbieConsoleCommandHandler


### PR DESCRIPTION
Fixes compilation error occuring after https://github.com/Centurion-Creative-Connect/System/pull/47